### PR TITLE
Bumped spellcheck action to latest version, since 0.23.0 is EOL

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: rojopolis/spellcheck-github-actions@0.23.0
+      - uses: rojopolis/spellcheck-github-actions@0.35.0
         name: Spellcheck
         with:
           config_path: .spellcheck_config.yml


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am sunsetting version 0.23.0 as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to version 0.35.0, so this PR offers an update to the latest version.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can see you have a configuration for [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, but no PRs, please let me know if I can help. I think you need to enable Dependabot for your account.

jonasbn